### PR TITLE
Add simple Othello game with unit tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,3 @@
 # LearnCodex
+
+This repository contains a simple command-line implementation of the game Othello (Reversi) in Python along with unit tests.

--- a/othello.py
+++ b/othello.py
@@ -1,0 +1,72 @@
+from typing import List, Tuple
+
+class Othello:
+    SIZE = 8
+    EMPTY = '.'
+    BLACK = 'B'
+    WHITE = 'W'
+
+    DIRECTIONS = [
+        (1, 0), (-1, 0), (0, 1), (0, -1),
+        (1, 1), (1, -1), (-1, 1), (-1, -1)
+    ]
+
+    def __init__(self) -> None:
+        self.board = [[self.EMPTY for _ in range(self.SIZE)] for _ in range(self.SIZE)]
+        mid = self.SIZE // 2
+        self.board[mid - 1][mid - 1] = self.WHITE
+        self.board[mid][mid] = self.WHITE
+        self.board[mid - 1][mid] = self.BLACK
+        self.board[mid][mid - 1] = self.BLACK
+        self.current = self.BLACK
+
+    def in_bounds(self, r: int, c: int) -> bool:
+        return 0 <= r < self.SIZE and 0 <= c < self.SIZE
+
+    def opponent(self, player: str) -> str:
+        return self.BLACK if player == self.WHITE else self.WHITE
+
+    def _captures_in_direction(self, r: int, c: int, dr: int, dc: int, player: str):
+        r += dr
+        c += dc
+        pieces = []
+        while self.in_bounds(r, c) and self.board[r][c] == self.opponent(player):
+            pieces.append((r, c))
+            r += dr
+            c += dc
+        if self.in_bounds(r, c) and self.board[r][c] == player and pieces:
+            return pieces
+        return []
+
+    def valid_moves(self, player: str):
+        moves = []
+        for r in range(self.SIZE):
+            for c in range(self.SIZE):
+                if self.board[r][c] != self.EMPTY:
+                    continue
+                for dr, dc in self.DIRECTIONS:
+                    if self._captures_in_direction(r, c, dr, dc, player):
+                        moves.append((r, c))
+                        break
+        return moves
+
+    def make_move(self, r: int, c: int) -> bool:
+        player = self.current
+        if (r, c) not in self.valid_moves(player):
+            return False
+        to_flip = []
+        for dr, dc in self.DIRECTIONS:
+            to_flip.extend(self._captures_in_direction(r, c, dr, dc, player))
+        self.board[r][c] = player
+        for fr, fc in to_flip:
+            self.board[fr][fc] = player
+        self.current = self.opponent(player)
+        return True
+
+    def is_game_over(self) -> bool:
+        return not self.valid_moves(self.current) and not self.valid_moves(self.opponent(self.current))
+
+    def score(self):
+        black = sum(row.count(self.BLACK) for row in self.board)
+        white = sum(row.count(self.WHITE) for row in self.board)
+        return {self.BLACK: black, self.WHITE: white}

--- a/test_othello.py
+++ b/test_othello.py
@@ -1,0 +1,25 @@
+import pytest
+from othello import Othello
+
+
+def test_initial_board():
+    game = Othello()
+    assert game.board[3][3] == Othello.WHITE
+    assert game.board[3][4] == Othello.BLACK
+    assert game.board[4][3] == Othello.BLACK
+    assert game.board[4][4] == Othello.WHITE
+
+
+def test_valid_moves_start():
+    game = Othello()
+    moves = set(game.valid_moves(Othello.BLACK))
+    expected = {(2, 3), (3, 2), (4, 5), (5, 4)}
+    assert moves == expected
+
+
+def test_move_flips():
+    game = Othello()
+    assert game.make_move(2, 3)
+    assert game.board[3][3] == Othello.BLACK
+    assert game.board[2][3] == Othello.BLACK
+    assert game.current == Othello.WHITE


### PR DESCRIPTION
## Summary
- Implement basic Othello (Reversi) engine with move validation, disc flipping, game-over detection, and scoring.
- Add unit tests covering initial board setup, legal move generation, and flipping logic.
- Update README to describe the project.

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689f1b699bac83228e5d6abf042a117a