### PR TITLE
Enable interactive terminal play for Othello

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,7 @@
 # LearnCodex
+
+This repository contains a simple command-line implementation of the game Othello (Reversi) in Python along with unit tests.
+
+## Playing
+
+Run `python play_othello.py` to start a two-player game in the terminal. Enter moves as `row col` using coordinates from 0 to 7. The program handles passes when no moves are available and prints the final score when the game ends.

--- a/othello.py
+++ b/othello.py
@@ -1,0 +1,83 @@
+from typing import List, Tuple
+
+
+class Othello:
+    SIZE = 8
+    EMPTY = '.'
+    BLACK = 'B'
+    WHITE = 'W'
+
+    DIRECTIONS = [
+        (1, 0), (-1, 0), (0, 1), (0, -1),
+        (1, 1), (1, -1), (-1, 1), (-1, -1)
+    ]
+
+    def __init__(self) -> None:
+        self.board = [[self.EMPTY for _ in range(self.SIZE)] for _ in range(self.SIZE)]
+        mid = self.SIZE // 2
+        self.board[mid - 1][mid - 1] = self.WHITE
+        self.board[mid][mid] = self.WHITE
+        self.board[mid - 1][mid] = self.BLACK
+        self.board[mid][mid - 1] = self.BLACK
+        self.current = self.BLACK
+
+    def in_bounds(self, r: int, c: int) -> bool:
+        return 0 <= r < self.SIZE and 0 <= c < self.SIZE
+
+    def opponent(self, player: str) -> str:
+        return self.BLACK if player == self.WHITE else self.WHITE
+
+    def _captures_in_direction(self, r: int, c: int, dr: int, dc: int, player: str):
+        r += dr
+        c += dc
+        pieces = []
+        while self.in_bounds(r, c) and self.board[r][c] == self.opponent(player):
+            pieces.append((r, c))
+            r += dr
+            c += dc
+        if self.in_bounds(r, c) and self.board[r][c] == player and pieces:
+            return pieces
+        return []
+
+    def valid_moves(self, player: str):
+        moves = []
+        for r in range(self.SIZE):
+            for c in range(self.SIZE):
+                if self.board[r][c] != self.EMPTY:
+                    continue
+                for dr, dc in self.DIRECTIONS:
+                    if self._captures_in_direction(r, c, dr, dc, player):
+                        moves.append((r, c))
+                        break
+        return moves
+
+    def make_move(self, r: int, c: int) -> bool:
+        player = self.current
+        if (r, c) not in self.valid_moves(player):
+            return False
+        to_flip = []
+        for dr, dc in self.DIRECTIONS:
+            to_flip.extend(self._captures_in_direction(r, c, dr, dc, player))
+        self.board[r][c] = player
+        for fr, fc in to_flip:
+            self.board[fr][fc] = player
+        self.current = self.opponent(player)
+        return True
+
+    def is_game_over(self) -> bool:
+        return not self.valid_moves(self.current) and not self.valid_moves(self.opponent(self.current))
+
+    def score(self):
+        black = sum(row.count(self.BLACK) for row in self.board)
+        white = sum(row.count(self.WHITE) for row in self.board)
+        return {self.BLACK: black, self.WHITE: white}
+
+    def board_str(self) -> str:
+        header = "  " + " ".join(str(i) for i in range(self.SIZE))
+        rows = [header]
+        for idx, row in enumerate(self.board):
+            rows.append(f"{idx} " + " ".join(row))
+        return "\n".join(rows)
+
+    def __str__(self) -> str:
+        return self.board_str()

--- a/play_othello.py
+++ b/play_othello.py
@@ -1,0 +1,45 @@
+from othello import Othello
+
+
+def print_board(game: Othello) -> None:
+    """Display the current board and the active player."""
+    print(game)
+    print(f"Current player: {game.current}\n")
+
+
+def main() -> None:
+    game = Othello()
+    while not game.is_game_over():
+        moves = game.valid_moves(game.current)
+        if not moves:
+            print(f"{game.current} has no valid moves and must pass.\n")
+            game.current = game.opponent(game.current)
+            continue
+
+        print_board(game)
+        move_input = input("Enter move as 'row col': ")
+        try:
+            r, c = map(int, move_input.split())
+        except ValueError:
+            print("Invalid input. Please enter row and column numbers separated by a space.\n")
+            continue
+
+        if not game.make_move(r, c):
+            print("Illegal move, try again.\n")
+
+    print_board(game)
+    scores = game.score()
+    print(
+        f"Game over. Black: {scores[Othello.BLACK]}, "
+        f"White: {scores[Othello.WHITE]}"
+    )
+    if scores[Othello.BLACK] > scores[Othello.WHITE]:
+        print("Black wins!")
+    elif scores[Othello.BLACK] < scores[Othello.WHITE]:
+        print("White wins!")
+    else:
+        print("It's a tie!")
+
+
+if __name__ == "__main__":
+    main()

--- a/test_othello.py
+++ b/test_othello.py
@@ -1,0 +1,41 @@
+import pytest
+from othello import Othello
+
+
+def test_initial_board():
+    game = Othello()
+    assert game.board[3][3] == Othello.WHITE
+    assert game.board[3][4] == Othello.BLACK
+    assert game.board[4][3] == Othello.BLACK
+    assert game.board[4][4] == Othello.WHITE
+
+
+def test_valid_moves_start():
+    game = Othello()
+    moves = set(game.valid_moves(Othello.BLACK))
+    expected = {(2, 3), (3, 2), (4, 5), (5, 4)}
+    assert moves == expected
+
+
+def test_move_flips():
+    game = Othello()
+    assert game.make_move(2, 3)
+    assert game.board[3][3] == Othello.BLACK
+    assert game.board[2][3] == Othello.BLACK
+    assert game.current == Othello.WHITE
+
+
+def test_board_str():
+    game = Othello()
+    expected = (
+        "  0 1 2 3 4 5 6 7\n"
+        "0 . . . . . . . .\n"
+        "1 . . . . . . . .\n"
+        "2 . . . . . . . .\n"
+        "3 . . . W B . . .\n"
+        "4 . . . B W . . .\n"
+        "5 . . . . . . . .\n"
+        "6 . . . . . . . .\n"
+        "7 . . . . . . . ."
+    )
+    assert game.board_str() == expected


### PR DESCRIPTION
## Summary
- Provide `board_str` and `__str__` methods to render the Othello board.
- Add `play_othello.py` script for two-player command-line gameplay.
- Document how to run the game and test board rendering with a new unit test.
- Use `__str__` in the CLI to avoid missing `board_str` errors when printing the board.

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689f1b699bac83228e5d6abf042a117a